### PR TITLE
Fix: Override collector's grpc header_list_size_max

### DIFF
--- a/pinpoint-collector/build/config/pinpoint-collector.properties
+++ b/pinpoint-collector/build/config/pinpoint-collector.properties
@@ -6,3 +6,7 @@
 ##########
 #
 #pinpoint.zookeeper.address=
+
+collector.receiver.grpc.agent.header_list_size_max=8KB
+collector.receiver.grpc.stat.header_list_size_max=8KB
+collector.receiver.grpc.span.header_list_size_max=8KB


### PR DESCRIPTION
```sh
cd pinpoint-docker/pinpoint-collector
docker build -t pinpoint-collector:0.0 .
docker tag pinpoint-collector:0.0 9ilbert/pinpoint-collector:0.0
```

use docker image '9ilbert/pinpoint-collector:0.0'